### PR TITLE
[36] Refactor FormCreatorContext

### DIFF
--- a/src/app/shared/components/Form/FormMarkdown/FormMarkdown.tsx
+++ b/src/app/shared/components/Form/FormMarkdown/FormMarkdown.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { TextField } from '@material-ui/core';
+import { useIntl } from 'react-intl';
+import { FormBox } from 'app/shared/components/Form/FormBox/FormBox';
+import { FabPopper } from 'app/shared/components/FabPopper/FabPopper';
+import { MarkdownCheatsheet } from 'app/shared/components/MarkdownCheatsheet/MarkdownCheatsheet';
+import { SimplyColor } from 'app/shared/types/color.type';
+
+export interface FormMarkdownProps {
+  color?: SimplyColor;
+  markdown?: string;
+  changeMarkdown?: (markdown: string) => void;
+}
+
+export const FormMarkdown = ({
+  color = 'primary',
+  markdown,
+  changeMarkdown,
+}: FormMarkdownProps): React.ReactElement => {
+  const intl = useIntl();
+
+  const onChangeMarkdown = (markdown: string): void => {
+    changeMarkdown && changeMarkdown(markdown);
+  };
+
+  return (
+    <div>
+      <FormBox
+        title="Markdown"
+        color={
+          color === 'primary' ? 'primaryLight' : 'secondaryLight'
+        }
+        contentVariant="contained"
+      >
+        <TextField
+          multiline
+          fullWidth
+          name="markdown"
+          color={color}
+          variant="standard"
+          className="code"
+          value={markdown}
+          onChange={(event) => onChangeMarkdown(event.target.value)}
+        ></TextField>
+      </FormBox>
+      <FabPopper
+        button={intl.formatMessage({
+          id: 'GLOBAL.LABEL.MARKDOWN_ABBREVIATION',
+          defaultMessage: 'MC',
+        })}
+        size="medium"
+        color={color}
+      >
+        <MarkdownCheatsheet color={color} />
+      </FabPopper>
+    </div>
+  );
+};

--- a/src/app/shared/components/QuestionSentence/QuestionSentence.styles.ts
+++ b/src/app/shared/components/QuestionSentence/QuestionSentence.styles.ts
@@ -1,6 +1,6 @@
 import { Theme } from '@material-ui/core';
 import { makeStyles } from '@material-ui/styles';
-import { QuestionSentenceProps } from 'app/shared/components/Form/QuestionSentence/QuestionSentence';
+import { QuestionSentenceProps } from 'app/shared/components/QuestionSentence/QuestionSentence';
 import { Color } from 'app/shared/types/color.type';
 
 export const useQuestionSentenceStyles = makeStyles(

--- a/src/app/shared/components/QuestionSentence/QuestionSentence.tsx
+++ b/src/app/shared/components/QuestionSentence/QuestionSentence.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TextField, Typography } from '@material-ui/core';
 import { Color } from 'app/shared/types/color.type';
-import { useQuestionSentenceStyles } from 'app/shared/components/Form/QuestionSentence/QuestionSentence.styles';
+import { useQuestionSentenceStyles } from 'app/shared/components/QuestionSentence/QuestionSentence.styles';
 
 export interface QuestionSentenceProps {
   text: string;

--- a/src/app/shared/context/FormCreatorContext/FormCreatorContext.actions.ts
+++ b/src/app/shared/context/FormCreatorContext/FormCreatorContext.actions.ts
@@ -2,9 +2,21 @@ import { ContextAction } from 'app/shared/interfaces/context.interface';
 import { FormElementValue } from 'app/shared/types/formElementValue.type';
 
 export enum FormCreatorContextActionType {
+  setTitle = 'setTitle',
+  setDescription = 'setDescription',
   setElementValue = 'setElementValue',
   setMarkdown = 'setMarkdown',
 }
+
+type SetTitleAction = ContextAction<
+  FormCreatorContextActionType.setTitle,
+  string
+>;
+
+type SetDescriptionAction = ContextAction<
+  FormCreatorContextActionType.setDescription,
+  string
+>;
 
 type SetFormElementValueAction = ContextAction<
   FormCreatorContextActionType.setElementValue,
@@ -17,5 +29,7 @@ type SetMarkdownAction = ContextAction<
 >;
 
 export type FormCreatorContextActions =
+  | SetTitleAction
+  | SetDescriptionAction
   | SetFormElementValueAction
   | SetMarkdownAction;

--- a/src/app/shared/context/FormCreatorContext/FormCreatorContext.tsx
+++ b/src/app/shared/context/FormCreatorContext/FormCreatorContext.tsx
@@ -9,9 +9,12 @@ import {
 import { FormElementValue } from 'app/shared/types/formElementValue.type';
 import { convertMarkdownToJson } from 'app/shared/utils/markdownRawToJson.utils';
 import { convertJsonToMarkdown } from 'app/shared/utils/markdownJsonToRaw.utils';
+import { MarkdownMock } from 'app/shared/mocks/markdown.mock';
 
 export interface FormCreatorContextState {
-  readonly form?: FormElement[];
+  readonly title?: string;
+  readonly description?: string;
+  readonly formElements?: FormElement[];
   readonly markdown?: string;
 }
 
@@ -26,8 +29,8 @@ export interface FormCreatorProviderProps {
 
 const initialContext: FormCreatorContextModel = {
   state: {
-    form: [],
-    markdown: '',
+    formElements: convertMarkdownToJson(MarkdownMock), // TODO: Temporary formElements, remove later
+    markdown: MarkdownMock, // TODO: Temporary markdown, remove later
   },
   dispatch: () => {
     noContextProviderWarning();
@@ -63,19 +66,30 @@ const FormCreatorReducer = (
   action: FormCreatorContextActions,
 ): FormCreatorContextState => {
   switch (action.type) {
-    case FormCreatorContextActionType.setElementValue:
-      const form =
-        updateFormElementValue(action.payload, state.form) ?? [];
+    case FormCreatorContextActionType.setTitle:
       return {
         ...state,
-        form,
-        markdown: convertJsonToMarkdown(form),
+        title: action.payload,
+      };
+    case FormCreatorContextActionType.setDescription:
+      return {
+        ...state,
+        description: action.payload,
+      };
+    case FormCreatorContextActionType.setElementValue:
+      const formElements =
+        updateFormElementValue(action.payload, state.formElements) ??
+        [];
+      return {
+        ...state,
+        formElements,
+        markdown: convertJsonToMarkdown(formElements),
       };
     case FormCreatorContextActionType.setMarkdown:
       return {
         ...state,
         markdown: action.payload,
-        form: convertMarkdownToJson(action.payload),
+        formElements: convertMarkdownToJson(action.payload),
       };
     default:
       throw new Error('Wrong action type provided');

--- a/src/app/shared/mocks/markdown.mock.ts
+++ b/src/app/shared/mocks/markdown.mock.ts
@@ -1,0 +1,34 @@
+export const MarkdownMock = `
+*# Group 1
+*## Section 1.1
+*\`\`\`
+  *###[3] Question sentence 1.1.1
+  *### Question sentence 1.1.2
+  *### Question sentence 1.1.3
+  *### Question sentence 1.1.4
+  *()[2] Radio 1
+  *()[32] Radio 2
+  *() Radio 3
+*\`\`\`
+
+*# Group 2
+*## Section 2.1
+*\`
+  *### Question sentence 2.1.1
+  *()[2] Radio button 1
+  *()[32] Radio button 2
+  *() Radio button 3
+*\`
+
+*# Group 3
+*\`
+  *### Question sentence 3.1
+  *[][1] Checkbox 1
+  *[][2] Checkbox 2
+  *[] Checkbox 3
+*\`
+*\`
+  *### Question sentence 3.2
+  *...
+*\`
+`;

--- a/src/app/shared/utils/markdownJsonToJsx.utils.tsx
+++ b/src/app/shared/utils/markdownJsonToJsx.utils.tsx
@@ -11,7 +11,7 @@ import { Weight } from 'app/shared/components/Weight/Weight';
 import { MarkdownRuleJsxConverter } from 'app/shared/types/markdownRuleConvertedElements.type';
 import { SetFormElementValue } from 'app/shared/types/setFormElementValue.type';
 import { FormControl } from 'app/shared/components/Form/FormControl/FormControl';
-import { QuestionSentence } from 'app/shared/components/Form/QuestionSentence/QuestionSentence';
+import { QuestionSentence } from 'app/shared/components/QuestionSentence/QuestionSentence';
 import { Color } from 'app/shared/types/color.type';
 import { QuestionGroup } from 'app/shared/components/QuestionGroup/QuestionGroup';
 import { QuestionItem } from 'app/shared/components/QuestionItem/QuestionItem';

--- a/src/app/views/Surveys/CreateSurvey/CreateSurvey.tsx
+++ b/src/app/views/Surveys/CreateSurvey/CreateSurvey.tsx
@@ -1,5 +1,5 @@
 import { useIntl } from 'react-intl';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import { Grid } from '@material-ui/core';
 import { Route, Switch, useRouteMatch } from 'react-router';
 import useLayoutStyles from 'app/shared/styles/layout.styles';
@@ -10,8 +10,8 @@ import { Tabs } from 'app/shared/components/Tabs/Tabs';
 import { Tab } from 'app/shared/interfaces/tab.interface';
 import { SurveyGraphicEditor } from 'app/views/Surveys/CreateSurvey/SurveyGraphicEditor/SurveyGraphicEditor';
 import { SurveyMarkdown } from 'app/views/Surveys/CreateSurvey/SurveyMarkdown/SurveyMarkdown';
-import { FormCreatorProvider } from 'app/shared/context/FormCreatorContext/FormCreatorContext';
-import { convertMarkdownToJson } from 'app/shared/utils/markdownRawToJson.utils';
+import { FormCreatorContext } from 'app/shared/context/FormCreatorContext/FormCreatorContext';
+import { FormCreatorContextActionType } from 'app/shared/context/FormCreatorContext/FormCreatorContext.actions';
 
 export const CreateSurvey = (): ReactElement => {
   const intl = useIntl();
@@ -36,44 +36,6 @@ export const CreateSurvey = (): ReactElement => {
       url: `${url}/markdown`,
     },
   ];
-  const [form, setForm] = useState({
-    title: '',
-    description: '',
-    markdown: `
-    *# Group 1
-    *## Section 1.1
-    *\`\`\`
-      *###[3] Question sentence 1.1.1
-      *### Question sentence 1.1.2
-      *### Question sentence 1.1.3
-      *### Question sentence 1.1.4
-      *()[2] Radio 1
-      *()[32] Radio 2
-      *() Radio 3
-    *\`\`\`
-  
-    *# Group 2
-    *## Section 2.1
-    *\`
-      *### Question sentence 2.1.1
-      *()[2] Radio button 1
-      *()[32] Radio button 2
-      *() Radio button 3
-    *\`
-  
-    *# Group 3
-    *\`
-      *### Question sentence 3.1
-      *[][1] Checkbox 1
-      *[][2] Checkbox 2
-      *[] Checkbox 3
-    *\`
-    *\`
-      *### Question sentence 3.2
-      *...
-    *\`
-    `, // TODO: Temporary markdown, remove later
-  });
 
   usePageTitle(
     intl.formatMessage({
@@ -82,57 +44,51 @@ export const CreateSurvey = (): ReactElement => {
     }),
   );
 
+  const { state, dispatch } = useContext(FormCreatorContext);
+
   const onChangeTitle = (title: string): void => {
-    setForm({
-      ...form,
-      title,
+    dispatch({
+      type: FormCreatorContextActionType.setTitle,
+      payload: title,
     });
   };
 
   const onChangeDescription = (description: string): void => {
-    setForm({
-      ...form,
-      description,
+    dispatch({
+      type: FormCreatorContextActionType.setDescription,
+      payload: description,
     });
   };
 
   return (
-    <FormCreatorProvider
-      // TODO: Remove initialState later
-      initialState={{
-        form: convertMarkdownToJson(form.markdown),
-        markdown: form.markdown,
-      }}
+    <Grid
+      className={`${content} ${surveyContainer}`}
+      container
+      spacing={2}
     >
-      <Grid
-        className={`${content} ${surveyContainer}`}
-        container
-        spacing={2}
-      >
-        <Grid item xs={12} className={surveySection}>
-          <FormHeader
-            editMode
-            title={form.title}
-            description={form.description}
-            color="secondary"
-            onChangeTitle={onChangeTitle}
-            onChangeDescription={onChangeDescription}
-          />
-        </Grid>
-        <Grid item xs={12} className={surveySection}>
-          <Tabs tabs={tabs} color="secondary"></Tabs>
-        </Grid>
-        <Grid item xs={12} className={surveySection}>
-          <Switch>
-            <Route exact path={path}>
-              <SurveyGraphicEditor />
-            </Route>
-            <Route path={`${path}/markdown`}>
-              <SurveyMarkdown />
-            </Route>
-          </Switch>
-        </Grid>
+      <Grid item xs={12} className={surveySection}>
+        <FormHeader
+          editMode
+          title={state.title}
+          description={state.description}
+          color="secondary"
+          onChangeTitle={onChangeTitle}
+          onChangeDescription={onChangeDescription}
+        />
       </Grid>
-    </FormCreatorProvider>
+      <Grid item xs={12} className={surveySection}>
+        <Tabs tabs={tabs} color="secondary"></Tabs>
+      </Grid>
+      <Grid item xs={12} className={surveySection}>
+        <Switch>
+          <Route exact path={path}>
+            <SurveyGraphicEditor />
+          </Route>
+          <Route path={`${path}/markdown`}>
+            <SurveyMarkdown />
+          </Route>
+        </Switch>
+      </Grid>
+    </Grid>
   );
 };

--- a/src/app/views/Surveys/CreateSurvey/SurveyGraphicEditor/SurveyGraphicEditor.tsx
+++ b/src/app/views/Surveys/CreateSurvey/SurveyGraphicEditor/SurveyGraphicEditor.tsx
@@ -6,7 +6,7 @@ import { FormElementValue } from 'app/shared/types/formElementValue.type';
 
 export const SurveyGraphicEditor = (): React.ReactElement => {
   const { state, dispatch } = useContext(FormCreatorContext);
-  const { form } = state;
+  const { formElements } = state;
 
   const onChangeFormElementValue = (
     id: string,
@@ -21,7 +21,7 @@ export const SurveyGraphicEditor = (): React.ReactElement => {
   return (
     <FormCreator
       color="secondary"
-      formElements={form || []}
+      formElements={formElements || []}
       changeFormElementValue={onChangeFormElementValue}
     />
   );

--- a/src/app/views/Surveys/CreateSurvey/SurveyMarkdown/SurveyMarkdown.tsx
+++ b/src/app/views/Surveys/CreateSurvey/SurveyMarkdown/SurveyMarkdown.tsx
@@ -1,15 +1,9 @@
-import { TextField } from '@material-ui/core';
 import React, { useContext } from 'react';
-import { useIntl } from 'react-intl';
-import { FormBox } from 'app/shared/components/Form/FormBox/FormBox';
-import { FabPopper } from 'app/shared/components/FabPopper/FabPopper';
-import { MarkdownCheatsheet } from 'app/shared/components/MarkdownCheatsheet/MarkdownCheatsheet';
 import { FormCreatorContext } from 'app/shared/context/FormCreatorContext/FormCreatorContext';
 import { FormCreatorContextActionType } from 'app/shared/context/FormCreatorContext/FormCreatorContext.actions';
+import { FormMarkdown } from 'app/shared/components/Form/FormMarkdown/FormMarkdown';
 
 export const SurveyMarkdown = (): React.ReactElement => {
-  const intl = useIntl();
-
   const { state, dispatch } = useContext(FormCreatorContext);
   const { markdown } = state;
 
@@ -21,33 +15,10 @@ export const SurveyMarkdown = (): React.ReactElement => {
   };
 
   return (
-    <div>
-      <FormBox
-        title="Markdown"
-        color="secondaryLight"
-        contentVariant="contained"
-      >
-        <TextField
-          multiline
-          fullWidth
-          name="markdown"
-          color="secondary"
-          variant="standard"
-          className="code"
-          value={markdown}
-          onChange={(event) => onChangeMarkdown(event.target.value)}
-        ></TextField>
-      </FormBox>
-      <FabPopper
-        button={intl.formatMessage({
-          id: 'GLOBAL.LABEL.MARKDOWN_ABBREVIATION',
-          defaultMessage: 'MC',
-        })}
-        size="medium"
-        color="secondary"
-      >
-        <MarkdownCheatsheet color="secondary" />
-      </FabPopper>
-    </div>
+    <FormMarkdown
+      color="secondary"
+      markdown={markdown}
+      changeMarkdown={(markdown) => onChangeMarkdown(markdown)}
+    />
   );
 };

--- a/src/app/views/Surveys/Surveys.tsx
+++ b/src/app/views/Surveys/Surveys.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { Route, Switch, useRouteMatch } from 'react-router';
 import { CreateSurvey } from 'app/views/Surveys/CreateSurvey/CreateSurvey';
 import { SurveysList } from 'app/views/Surveys/SurveysList/SurveysList';
+import { FormCreatorProvider } from 'app/shared/context/FormCreatorContext/FormCreatorContext';
 
 export const Surveys = (): ReactElement => {
   const { path } = useRouteMatch();
@@ -11,7 +12,9 @@ export const Surveys = (): ReactElement => {
         <SurveysList />
       </Route>
       <Route path={`${path}/new`}>
-        <CreateSurvey />
+        <FormCreatorProvider>
+          <CreateSurvey />
+        </FormCreatorProvider>
       </Route>
     </Switch>
   );


### PR DESCRIPTION
- Put title and description of the form into the context
- Separate FormMarkdown component to make it easier to reuse
- Move QuestionSentence component to different directory
- Wrap CreateSurvey component by FromCreatorProvider