### PR TITLE
[39] Add logic for Aside items

### DIFF
--- a/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles.ts
+++ b/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles.ts
@@ -1,10 +1,51 @@
 import { Theme } from '@material-ui/core';
 import { makeStyles } from '@material-ui/styles';
+import { AsidePosition } from 'app/shared/types/asidePosition.type';
 import { SimplyColor } from 'app/shared/types/color.type';
 import { pxToRem } from 'app/shared/utils/styles.utils';
 
+const getAsidePosition = (
+  position: AsidePosition,
+  isFlying: boolean,
+): 'fixed' | 'relative' | 'static' => {
+  switch (position) {
+    case 'fixed':
+    case 'static':
+      return position;
+    case 'sticky':
+      return isFlying ? 'fixed' : 'relative';
+  }
+};
+
+const getAsideTop = (
+  position: AsidePosition,
+  isFlying: boolean,
+): string | undefined => {
+  switch (position) {
+    case 'fixed':
+      return '50%';
+    case 'sticky':
+      return isFlying ? '50%' : '0';
+  }
+};
+
+const getAsideTransform = (
+  position: AsidePosition,
+  isFlying: boolean,
+): string | undefined => {
+  switch (position) {
+    case 'fixed':
+      return 'translateY(-50%)';
+    case 'sticky':
+      return isFlying ? 'translateY(-50%)' : undefined;
+  }
+};
+
 export const useAsideGraphicEditor = makeStyles((theme: Theme) => ({
   root: {
+    position: 'absolute',
+    left: 0,
+
     '& > $asideGraphicEditor:hover': {
       '& + $blanket': {
         left: 0,
@@ -14,15 +55,23 @@ export const useAsideGraphicEditor = makeStyles((theme: Theme) => ({
       },
     },
   },
-  asideGraphicEditor: ({ color }: { color: SimplyColor }) => ({
-    position: 'fixed',
-    top: '50%',
+  asideGraphicEditor: ({
+    color,
+    position,
+    isFlying,
+  }: {
+    color: SimplyColor;
+    position: AsidePosition;
+    isFlying: boolean;
+  }) => ({
+    position: getAsidePosition(position, isFlying),
+    top: getAsideTop(position, isFlying),
     left: '1rem',
     width: 'auto',
     margin: 0,
-    transform: 'translateY(-50%)',
     color: theme.palette[color].main,
     zIndex: 2,
+    transform: getAsideTransform(position, isFlying),
   }),
   blanket: {
     position: 'fixed',

--- a/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles.ts
+++ b/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles.ts
@@ -45,6 +45,9 @@ export const useAsideGraphicEditor = makeStyles((theme: Theme) => ({
     opacity: 0,
     transition: 'opacity 0.3s ease-in',
   },
+  nameItemActive: {
+    fontWeight: theme.typography.fontWeightBold,
+  },
   circleItem: {
     display: 'flex',
     minWidth: pxToRem(30),

--- a/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles.ts
+++ b/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles.ts
@@ -4,22 +4,50 @@ import { SimplyColor } from 'app/shared/types/color.type';
 import { pxToRem } from 'app/shared/utils/styles.utils';
 
 export const useAsideGraphicEditor = makeStyles((theme: Theme) => ({
+  root: {
+    '& > $asideGraphicEditor:hover': {
+      '& + $blanket': {
+        left: 0,
+      },
+      '& $nameItem': {
+        opacity: 1,
+      },
+    },
+  },
   asideGraphicEditor: ({ color }: { color: SimplyColor }) => ({
     position: 'fixed',
     top: '50%',
-    left: '0.5%',
+    left: '1rem',
     width: 'auto',
     margin: 0,
     transform: 'translateY(-50%)',
     color: theme.palette[color].main,
+    zIndex: 1,
+
+    '&:hover': {
+      '& $nameItem': {
+        opacity: 1,
+      },
+    },
   }),
-  itemGraphicEditor: {
+  blanket: {
+    position: 'fixed',
+    width: '50%',
+    top: 0,
+    bottom: 0,
+    left: '-50%',
+    backgroundImage: `linear-gradient(to right, ${theme.palette.background.default}, rgba(255,0,0,0))`,
+    transition: 'left 0.3s ease-in',
+  },
+  item: {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-evenly',
+    justifyContent: 'flex-start',
   },
   nameItem: {
     marginLeft: pxToRem(10),
+    opacity: 0,
+    transition: 'opacity 0.3s ease-in',
   },
   circleItem: {
     display: 'flex',

--- a/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles.ts
+++ b/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles.ts
@@ -22,13 +22,7 @@ export const useAsideGraphicEditor = makeStyles((theme: Theme) => ({
     margin: 0,
     transform: 'translateY(-50%)',
     color: theme.palette[color].main,
-    zIndex: 1,
-
-    '&:hover': {
-      '& $nameItem': {
-        opacity: 1,
-      },
-    },
+    zIndex: 2,
   }),
   blanket: {
     position: 'fixed',
@@ -38,11 +32,13 @@ export const useAsideGraphicEditor = makeStyles((theme: Theme) => ({
     left: '-50%',
     backgroundImage: `linear-gradient(to right, ${theme.palette.background.default}, rgba(255,0,0,0))`,
     transition: 'left 0.3s ease-in',
+    zIndex: 1,
   },
   item: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-start',
+    cursor: 'pointer',
   },
   nameItem: {
     marginLeft: pxToRem(10),

--- a/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.tsx
+++ b/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.tsx
@@ -1,10 +1,12 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import { Grid, Typography } from '@material-ui/core';
 import { Circle } from 'app/shared/components/Circle/Circle';
 import { useAsideGraphicEditor } from 'app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles';
 import { AsideItem } from 'app/shared/interfaces/asideItem.interface';
 import { SimplyColor } from 'app/shared/types/color.type';
 import { CircleVariant } from 'app/shared/types/circleVariant.type';
+import { IntersectionContext } from 'app/shared/context/IntersectionContext/IntersectionContext';
+import { IntersectionState } from 'app/shared/enums/intersectionState.enum';
 
 export interface AsideGraphicEditorProps {
   items: AsideItem[];
@@ -17,15 +19,18 @@ export const AsideGraphicEditor = ({
   direction,
   color = 'primary',
 }: AsideGraphicEditorProps): ReactElement => {
+  const { state } = useContext(IntersectionContext);
+
   const styles = useAsideGraphicEditor({ color });
 
   const getCircleVariant = (item: AsideItem): CircleVariant => {
-    switch (item.status) {
-      case 'active':
+    const status = state.itemsState[item.id];
+    switch (status || item.status) {
+      case IntersectionState.active:
         return 'active';
-      case 'pending':
+      case IntersectionState.pending:
         return 'outlined';
-      case 'done':
+      case IntersectionState.done:
         return 'contained';
     }
   };

--- a/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.tsx
+++ b/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.tsx
@@ -2,29 +2,24 @@ import React, { ReactElement } from 'react';
 import { Grid, Typography } from '@material-ui/core';
 import { Circle } from 'app/shared/components/Circle/Circle';
 import { useAsideGraphicEditor } from 'app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles';
-import { AsideGraphic } from 'app/shared/interfaces/asideGraphic.interface';
+import { AsideItem } from 'app/shared/interfaces/asideItem.interface';
 import { SimplyColor } from 'app/shared/types/color.type';
 import { CircleVariant } from 'app/shared/types/circleVariant.type';
 
 export interface AsideGraphicEditorProps {
-  circleEditor: AsideGraphic[];
+  items: AsideItem[];
   direction: 'column' | 'row';
   color?: SimplyColor;
 }
 
 export const AsideGraphicEditor = ({
-  circleEditor,
+  items,
   direction,
   color = 'primary',
 }: AsideGraphicEditorProps): ReactElement => {
-  const {
-    asideGraphicEditor,
-    itemGraphicEditor,
-    nameItem,
-    circleItem,
-  } = useAsideGraphicEditor({ color });
+  const styles = useAsideGraphicEditor({ color });
 
-  const getCircleVariant = (item: AsideGraphic): CircleVariant => {
+  const getCircleVariant = (item: AsideItem): CircleVariant => {
     switch (item.status) {
       case 'active':
         return 'active';
@@ -35,27 +30,41 @@ export const AsideGraphicEditor = ({
     }
   };
 
-  const asideEditor = circleEditor.map((item) => (
-    <Grid className={itemGraphicEditor} key={item.id} item>
-      <div className={circleItem}>
+  const scrollToItem = (item: AsideItem): void => {
+    document.getElementById(item.id)?.scrollIntoView({
+      behavior: 'smooth',
+    });
+  };
+
+  const asideEditor = items.map((item) => (
+    <Grid
+      className={styles.item}
+      key={item.id}
+      item
+      onClick={() => scrollToItem(item)}
+    >
+      <div className={styles.circleItem}>
         <Circle
           variant={getCircleVariant(item)}
           color={color}
           size={item.type === 'group' ? 'medium' : 'small'}
         />
       </div>
-      <Typography className={nameItem}>{item.name}</Typography>
+      <Typography className={styles.nameItem}>{item.name}</Typography>
     </Grid>
   ));
 
   return (
-    <Grid
-      className={asideGraphicEditor}
-      container
-      spacing={2}
-      direction={direction}
-    >
-      {asideEditor}
-    </Grid>
+    <div className={styles.root}>
+      <Grid
+        className={styles.asideGraphicEditor}
+        container
+        spacing={2}
+        direction={direction}
+      >
+        {asideEditor}
+      </Grid>
+      <div className={styles.blanket}></div>
+    </div>
   );
 };

--- a/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.tsx
+++ b/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.tsx
@@ -35,6 +35,16 @@ export const AsideGraphicEditor = ({
     }
   };
 
+  const getNameActiveClass = (
+    item: AsideItem,
+  ): string | undefined => {
+    const status = state.itemsState[item.id];
+    switch (status || item.status) {
+      case IntersectionState.active:
+        return styles.nameItemActive;
+    }
+  };
+
   const scrollToItem = (item: AsideItem): void => {
     document.getElementById(item.id)?.scrollIntoView({
       behavior: 'smooth',
@@ -55,7 +65,11 @@ export const AsideGraphicEditor = ({
           size={item.type === 'group' ? 'medium' : 'small'}
         />
       </div>
-      <Typography className={styles.nameItem}>{item.name}</Typography>
+      <Typography
+        className={`${styles.nameItem} ${getNameActiveClass(item)}`}
+      >
+        {item.name}
+      </Typography>
     </Grid>
   ));
 

--- a/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.tsx
+++ b/src/app/shared/components/AsideGraphicEditor/AsideGraphicEditor.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useContext } from 'react';
+import React, {
+  ReactElement,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { Grid, Typography } from '@material-ui/core';
 import { Circle } from 'app/shared/components/Circle/Circle';
 import { useAsideGraphicEditor } from 'app/shared/components/AsideGraphicEditor/AsideGraphicEditor.styles';
@@ -7,21 +13,51 @@ import { SimplyColor } from 'app/shared/types/color.type';
 import { CircleVariant } from 'app/shared/types/circleVariant.type';
 import { IntersectionContext } from 'app/shared/context/IntersectionContext/IntersectionContext';
 import { IntersectionState } from 'app/shared/enums/intersectionState.enum';
+import { AsidePosition } from 'app/shared/types/asidePosition.type';
 
 export interface AsideGraphicEditorProps {
   items: AsideItem[];
   direction: 'column' | 'row';
+  position?: AsidePosition;
   color?: SimplyColor;
 }
 
 export const AsideGraphicEditor = ({
   items,
   direction,
+  position = 'sticky',
   color = 'primary',
 }: AsideGraphicEditorProps): ReactElement => {
   const { state } = useContext(IntersectionContext);
+  const [isFlying, setFlying] = useState(false);
+  const styles = useAsideGraphicEditor({ color, position, isFlying });
+  const asideRef = useRef<HTMLDivElement>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
 
-  const styles = useAsideGraphicEditor({ color });
+  useEffect(() => {
+    if (position === 'sticky') {
+      window.addEventListener('scroll', setIsFixedStatus, true);
+      return () => {
+        window.removeEventListener('scroll', setIsFixedStatus, true);
+      };
+    }
+  });
+
+  const setIsFixedStatus = () => {
+    if (asideRef.current && parentRef.current) {
+      const asideRect = asideRef.current?.getBoundingClientRect();
+      const parentRect = parentRef.current?.getBoundingClientRect();
+
+      const isAboveCenterOfScreen =
+        asideRect.top + asideRect.height / 2 <=
+        window.innerHeight / 2;
+      const isAboveInitPosition = asideRect.top < parentRect.top;
+      const shouldBeFixed =
+        !isAboveInitPosition && isAboveCenterOfScreen;
+
+      setFlying(shouldBeFixed);
+    }
+  };
 
   const getCircleVariant = (item: AsideItem): CircleVariant => {
     const status = state.itemsState[item.id];
@@ -74,8 +110,9 @@ export const AsideGraphicEditor = ({
   ));
 
   return (
-    <div className={styles.root}>
+    <div ref={parentRef} className={styles.root}>
       <Grid
+        ref={asideRef}
         className={styles.asideGraphicEditor}
         container
         spacing={2}

--- a/src/app/shared/components/Circle/Circle.styles.ts
+++ b/src/app/shared/components/Circle/Circle.styles.ts
@@ -56,5 +56,7 @@ export const useCircleStyles = makeStyles((theme: Theme) => ({
     color: theme.palette[color].contrastText,
     backgroundColor: getBackgroudColor(theme, color, variant),
     border: getBorder(theme, color, variant),
+    transition:
+      'background-color 0.3s ease-in, border-width 0.3s ease-in',
   }),
 }));

--- a/src/app/shared/components/Form/FormBox/FormBox.tsx
+++ b/src/app/shared/components/Form/FormBox/FormBox.tsx
@@ -12,6 +12,7 @@ import { Size } from 'app/shared/types/size.type';
 import { getSimplyColor } from 'app/shared/utils/color.utils';
 
 export interface FormBoxProps {
+  id?: string;
   title: string | React.ReactNode;
   size?: Size;
   color?: Color;
@@ -25,6 +26,7 @@ export interface FormBoxProps {
 export const FormBox: React.FC<
   React.PropsWithChildren<FormBoxProps>
 > = ({
+  id,
   title,
   size = 'medium',
   color = 'primary',
@@ -66,7 +68,7 @@ export const FormBox: React.FC<
   );
 
   return (
-    <div>
+    <div id={id}>
       <Grid container className={`${styles.header}`}>
         <Grid item xs={12}>
           {titleElement}

--- a/src/app/shared/components/Form/FormBox/FormBox.tsx
+++ b/src/app/shared/components/Form/FormBox/FormBox.tsx
@@ -45,8 +45,17 @@ export const FormBox: React.FC<
   const itemsIntersectionState = useOnScreen([ref]);
 
   useEffect(() => {
+    const setIntersectionState = (): void => {
+      if (id && state.itemsState[id] !== itemsIntersectionState[id]) {
+        dispatch({
+          type: IntersectionContextActionType.setIntersection,
+          payload: { id, state: itemsIntersectionState[id] },
+        });
+      }
+    };
+
     setIntersectionState();
-  }, [id, itemsIntersectionState]);
+  }, [id, itemsIntersectionState, state, dispatch]);
 
   const styles = useFormBoxStyles({
     size,
@@ -57,15 +66,6 @@ export const FormBox: React.FC<
   const headerTextVariant: Record<Size, TypographyVariant> = {
     small: 'body1',
     medium: 'h3',
-  };
-
-  const setIntersectionState = (): void => {
-    if (id && state.itemsState[id] !== itemsIntersectionState[id]) {
-      dispatch({
-        type: IntersectionContextActionType.setIntersection,
-        payload: { id, state: itemsIntersectionState[id] },
-      });
-    }
   };
 
   const onChangeTitle = (title: string): void => {

--- a/src/app/shared/components/Form/FormBox/FormBox.tsx
+++ b/src/app/shared/components/Form/FormBox/FormBox.tsx
@@ -4,12 +4,15 @@ import {
   Typography,
   TypographyVariant,
 } from '@material-ui/core';
-import React from 'react';
+import React, { useContext, useRef, useEffect } from 'react';
 import { useFormBoxStyles } from 'app/shared/components/Form/FormBox/FormBox.styles';
 import { Color } from 'app/shared/types/color.type';
 import { BackgroundVariant } from 'app/shared/types/backgroundVariant.type';
 import { Size } from 'app/shared/types/size.type';
 import { getSimplyColor } from 'app/shared/utils/color.utils';
+import { IntersectionContext } from 'app/shared/context/IntersectionContext/IntersectionContext';
+import { IntersectionContextActionType } from 'app/shared/context/IntersectionContext/IntersectionContext.actions';
+import { useOnScreen } from 'app/shared/hooks/useOnScreen';
 
 export interface FormBoxProps {
   id?: string;
@@ -37,16 +40,32 @@ export const FormBox: React.FC<
   changeTitle,
   children,
 }: React.PropsWithChildren<FormBoxProps>): React.ReactElement => {
+  const { state, dispatch } = useContext(IntersectionContext);
+  const ref = useRef(null);
+  const itemsIntersectionState = useOnScreen([ref]);
+
+  useEffect(() => {
+    setIntersectionState();
+  }, [id, itemsIntersectionState]);
+
   const styles = useFormBoxStyles({
     size,
     color,
     headerVariant,
     contentVariant,
   });
-
   const headerTextVariant: Record<Size, TypographyVariant> = {
     small: 'body1',
     medium: 'h3',
+  };
+
+  const setIntersectionState = (): void => {
+    if (id && state.itemsState[id] !== itemsIntersectionState[id]) {
+      dispatch({
+        type: IntersectionContextActionType.setIntersection,
+        payload: { id, state: itemsIntersectionState[id] },
+      });
+    }
   };
 
   const onChangeTitle = (title: string): void => {
@@ -68,7 +87,7 @@ export const FormBox: React.FC<
   );
 
   return (
-    <div id={id}>
+    <div id={id} ref={ref}>
       <Grid container className={`${styles.header}`}>
         <Grid item xs={12}>
           {titleElement}

--- a/src/app/shared/components/Form/FormCreator/FormCreator.tsx
+++ b/src/app/shared/components/Form/FormCreator/FormCreator.tsx
@@ -14,6 +14,7 @@ import {
   SetFormElementValue,
 } from 'app/shared/types/formCreatorAction.type';
 import { generateAsideItemsFromFormElements } from 'app/shared/utils/aside.utils';
+import { IntersectionProvider } from 'app/shared/context/IntersectionContext/IntersectionContext';
 
 export interface FormCreatorProps {
   formElements: FormElement[];
@@ -70,7 +71,7 @@ export const FormCreator = ({
   );
 
   return (
-    <div>
+    <IntersectionProvider>
       <AsideGraphicEditor
         direction="column"
         color={color}
@@ -79,6 +80,6 @@ export const FormCreator = ({
       <Grid container direction="column" className={styles.form}>
         {content}
       </Grid>
-    </div>
+    </IntersectionProvider>
   );
 };

--- a/src/app/shared/components/Form/FormCreator/FormCreator.tsx
+++ b/src/app/shared/components/Form/FormCreator/FormCreator.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid } from '@material-ui/core';
 import { useIntl } from 'react-intl';
 import { AsideGraphicEditor } from 'app/shared/components/AsideGraphicEditor/AsideGraphicEditor';
-import { AsideGraphic } from 'app/shared/interfaces/asideGraphic.interface';
+import { AsideItem } from 'app/shared/interfaces/asideItem.interface';
 import { convertMarkdownRulesJsonToJsx } from 'app/shared/utils/markdownJsonToJsx.utils';
 import { FormElementValue } from 'app/shared/types/formElementValue.type';
 import { useFormCreatorStyles } from 'app/shared/components/Form/FormCreator/FormCreator.styles';
@@ -13,6 +13,7 @@ import {
   AddFormElement,
   SetFormElementValue,
 } from 'app/shared/types/formCreatorAction.type';
+import { generateAsideItemsFromFormElements } from 'app/shared/utils/aside.utils';
 
 export interface FormCreatorProps {
   formElements: FormElement[];
@@ -29,26 +30,6 @@ export const FormCreator = ({
 }: FormCreatorProps): React.ReactElement => {
   const intl = useIntl();
   const styles = useFormCreatorStyles();
-  const circleEditorGraphic: AsideGraphic[] = [
-    {
-      id: 'test 1',
-      name: 'test 1',
-      status: 'done',
-      type: 'group',
-    },
-    {
-      id: 'test 2',
-      name: 'test 2',
-      status: 'active',
-      type: 'section',
-    },
-    {
-      id: 'test 3',
-      name: 'test 3',
-      status: 'pending',
-      type: 'section',
-    },
-  ];
   const placeholders: Partial<Record<MarkdownRuleType, string>> = {
     textInput: intl.formatMessage({
       id: 'FORM_CREATOR.PLACEHOLDER.TEXT_INPUT',
@@ -84,16 +65,20 @@ export const FormCreator = ({
     true,
   );
 
+  const asideItems: AsideItem[] = generateAsideItemsFromFormElements(
+    formElements,
+  );
+
   return (
     <div>
-      <Grid container direction="column" className={styles.form}>
-        {content}
-      </Grid>
       <AsideGraphicEditor
         direction="column"
         color={color}
-        circleEditor={circleEditorGraphic}
+        items={asideItems}
       />
+      <Grid container direction="column" className={styles.form}>
+        {content}
+      </Grid>
     </div>
   );
 };

--- a/src/app/shared/context/IntersectionContext/IntersectionContext.actions.ts
+++ b/src/app/shared/context/IntersectionContext/IntersectionContext.actions.ts
@@ -1,0 +1,13 @@
+import { IntersectionState } from 'app/shared/enums/intersectionState.enum';
+import { ContextAction } from 'app/shared/interfaces/context.interface';
+
+export enum IntersectionContextActionType {
+  setIntersection = 'setIntersection',
+}
+
+type SetIntersectionAction = ContextAction<
+  IntersectionContextActionType.setIntersection,
+  { id: string; state: IntersectionState }
+>;
+
+export type IntersectionContextActions = SetIntersectionAction;

--- a/src/app/shared/context/IntersectionContext/IntersectionContext.tsx
+++ b/src/app/shared/context/IntersectionContext/IntersectionContext.tsx
@@ -1,0 +1,70 @@
+import React, { createContext, useReducer } from 'react';
+import { noContextProviderWarning } from 'app/shared/utils/context.utils';
+import { ContextModel } from 'app/shared/interfaces/context.interface';
+import {
+  IntersectionContextActions,
+  IntersectionContextActionType,
+} from 'app/shared/context/IntersectionContext/IntersectionContext.actions';
+import { IntersectionState } from 'app/shared/enums/intersectionState.enum';
+
+export interface IntersectionContextState {
+  readonly itemsState: Record<string, IntersectionState>;
+}
+
+export type IntersectionContextModel = ContextModel<
+  IntersectionContextState,
+  IntersectionContextActions
+>;
+
+export interface IntersectionProviderProps {
+  initialState?: IntersectionContextState;
+}
+
+const initialContext: IntersectionContextModel = {
+  state: {
+    itemsState: {},
+  },
+  dispatch: () => {
+    noContextProviderWarning();
+  },
+};
+
+export const IntersectionContext = createContext<IntersectionContextModel>(
+  initialContext,
+);
+
+const IntersectionReducer = (
+  state: IntersectionContextState,
+  action: IntersectionContextActions,
+): IntersectionContextState => {
+  switch (action.type) {
+    case IntersectionContextActionType.setIntersection:
+      return {
+        ...state,
+        itemsState: {
+          ...state.itemsState,
+          [action.payload.id]: action.payload.state,
+        },
+      };
+    default:
+      throw new Error('Wrong action type provided');
+  }
+};
+
+export const IntersectionProvider = ({
+  initialState,
+  children,
+}: React.PropsWithChildren<IntersectionProviderProps>): React.ReactElement => {
+  const [state, dispatch] = useReducer(
+    IntersectionReducer,
+    initialState || initialContext.state,
+  );
+
+  const refsState = { state, dispatch };
+
+  return (
+    <IntersectionContext.Provider value={{ ...refsState }}>
+      {children}
+    </IntersectionContext.Provider>
+  );
+};

--- a/src/app/shared/enums/intersectionState.enum.ts
+++ b/src/app/shared/enums/intersectionState.enum.ts
@@ -1,0 +1,5 @@
+export enum IntersectionState {
+  pending = 'pending',
+  active = 'active',
+  done = 'done',
+}

--- a/src/app/shared/hooks/useOnScreen.ts
+++ b/src/app/shared/hooks/useOnScreen.ts
@@ -34,7 +34,7 @@ export const useOnScreen = (
     return () => {
       observer.disconnect();
     };
-  }, []);
+  });
 
   return isIntersecting;
 };

--- a/src/app/shared/hooks/useOnScreen.ts
+++ b/src/app/shared/hooks/useOnScreen.ts
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { IntersectionState } from 'app/shared/enums/intersectionState.enum';
+
+export const useOnScreen = (
+  refs: React.RefObject<Element>[],
+): Record<string, IntersectionState> => {
+  const [isIntersecting, setIntersecting] = useState({});
+
+  const observer = new IntersectionObserver((entries) => {
+    const intersectionMap = { ...isIntersecting } as Record<
+      string,
+      IntersectionState
+    >;
+    entries.forEach((entry) => {
+      const id = entry.target.getAttribute('id');
+      if (id) {
+        const state = entry.isIntersecting
+          ? IntersectionState.active
+          : entry.boundingClientRect.bottom < 0
+          ? IntersectionState.done
+          : IntersectionState.pending;
+        intersectionMap[id] = state;
+      }
+    });
+    setIntersecting(intersectionMap);
+  });
+
+  useEffect(() => {
+    refs.forEach((ref) => {
+      if (ref.current) {
+        observer.observe(ref.current as Element);
+      }
+    });
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return isIntersecting;
+};

--- a/src/app/shared/interfaces/asideItem.interface.ts
+++ b/src/app/shared/interfaces/asideItem.interface.ts
@@ -1,6 +1,8 @@
+import { IntersectionState } from 'app/shared/enums/intersectionState.enum';
+
 export interface AsideItem {
   id: string;
   name: string;
-  status: 'pending' | 'active' | 'done';
+  status?: IntersectionState;
   type: 'group' | 'section';
 }

--- a/src/app/shared/interfaces/asideItem.interface.ts
+++ b/src/app/shared/interfaces/asideItem.interface.ts
@@ -1,4 +1,4 @@
-export interface AsideGraphic {
+export interface AsideItem {
   id: string;
   name: string;
   status: 'pending' | 'active' | 'done';

--- a/src/app/shared/types/asidePosition.type.ts
+++ b/src/app/shared/types/asidePosition.type.ts
@@ -1,0 +1,1 @@
+export type AsidePosition = 'fixed' | 'sticky' | 'static';

--- a/src/app/shared/utils/aside.utils.ts
+++ b/src/app/shared/utils/aside.utils.ts
@@ -1,0 +1,29 @@
+import { AsideItem } from 'app/shared/interfaces/asideItem.interface';
+import { FormElement } from 'app/shared/interfaces/formElement.interface';
+
+export const generateAsideItemsFromFormElements = (
+  formElements: FormElement[],
+): AsideItem[] => {
+  const asideItems: AsideItem[] = [];
+  formElements
+    ?.filter(
+      (formElement) =>
+        formElement.type === 'group' ||
+        formElement.type === 'section',
+    )
+    .forEach((formElement) => {
+      asideItems.push({
+        id: formElement.id,
+        name: formElement.value as string,
+        type: formElement.type as 'group' | 'section',
+        status: 'pending',
+      });
+      const children =
+        formElement.children &&
+        generateAsideItemsFromFormElements(formElement.children);
+      if (children) {
+        asideItems.push(...children);
+      }
+    });
+  return asideItems;
+};

--- a/src/app/shared/utils/aside.utils.ts
+++ b/src/app/shared/utils/aside.utils.ts
@@ -16,7 +16,6 @@ export const generateAsideItemsFromFormElements = (
         id: formElement.id,
         name: formElement.value as string,
         type: formElement.type as 'group' | 'section',
-        status: 'pending',
       });
       const children =
         formElement.children &&

--- a/src/app/shared/utils/markdownJsonToJsx.utils.tsx
+++ b/src/app/shared/utils/markdownJsonToJsx.utils.tsx
@@ -96,6 +96,7 @@ export const convertMarkdownGroupToJsx = (
 ): React.ReactElement => {
   return (
     <FormBox
+      id={markdownRuleElementJson.id}
       key={markdownRuleElementJson.id}
       title={markdownRuleElementJson.value}
       color={props?.color}
@@ -129,6 +130,7 @@ export const convertMarkdownSectionToJsx = (
 ): React.ReactElement => {
   return (
     <FormBox
+      id={markdownRuleElementJson.id}
       key={markdownRuleElementJson.id}
       title={markdownRuleElementJson.value}
       color={props?.color}


### PR DESCRIPTION
# Use items from form in aside

- Add logic to get items for aside from the form elements
- Add styles to show blanket and name of aside items on hover
- Add logic to scroll to elements in form by clicking on items in aside

# Add logic to mark aside items
- Create useOnScreen hook to observe intersection state of the elements
- Create IntersectionContext to store intersection state of the elements
- Use state from IntersectionContext to mark items in AsideGraphicEditor component
- Use useOnScreen and IntersectionContext in FormBox component
- Add animation in circle component for border and background color

# Make Aside sticky
- Add logic to change position of Aside based on the scroll position